### PR TITLE
Prefer /usr/local/bin/bash over /usr/bin/bas over ${PATH}

### DIFF
--- a/twa
+++ b/twa
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S-P/usr/local/bin:/usr/bin:${PATH} bash
 
 # twa: a tiny website auditing script
 


### PR DESCRIPTION
So, on macOS X Sierra (10.12.6), we get bash 3.2.57(1)-release instead of bash 4.0.  Of course, twa requires the latter.

We can use `brew` to install a newer bash in /usr/local/bin, but then we need to make sure that this gets picked up by those scripts that care -- like `twa`.

I have a trivial one-line change to the "shebang" to achieve this goal, which is included in this PR.