### PR TITLE
Added lightweight alpine docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.6
+
+LABEL name twa
+LABEL src "https://github.com/woodruffw/twa"
+LABEL creator woodruffw
+LABEL dockerfile_maintenance khast3x
+LABEL desc "A tiny web auditor with strong opinions."
+
+RUN apk add --no-cache bash git curl ncurses \ 
+&& git clone https://github.com/woodruffw/twa.git
+WORKDIR twa
+RUN bash 
+ENTRYPOINT [ "./twa" ]
+CMD  ["-h"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ $ echo "score: ${score}"
 Like `twa`, `tscore` is opinionated. You can change its opinions (i.e., its score weights)
 by editing it.
 
+### Docker
+
+`twa` can be from a lightweight (29MB) Alpine Docker container.  
+
+```bash
+$ git clone https://github.com/woodruffw/twa.git
+$ cd twa
+$ docker build -t twa .
+$ docker run -it twa:latest -vw google.com
+```
+
+
 ## Contributing
 
 Check out the [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
Hello,  

This PR adds a `Dockerfile` based on the tiny Alpine linux container.  
Usage is very straightforward, as shown in the `README` instructions.  
This enables an easier integration of `twa` in CI/CD environments to scan web servers automatically, and ensure getting the latest version of your code.  I hope you find it worthwhile.

Best regards,